### PR TITLE
build: make: use jemalloc by default and allow opt-in to scudo (1/4)

### DIFF
--- a/core/config_sanitizers.mk
+++ b/core/config_sanitizers.mk
@@ -325,7 +325,7 @@ ifneq ($(filter address thread hwaddress,$(my_sanitize)),)
 endif
 
 # Or if disabled globally.
-ifeq ($(PRODUCT_DISABLE_SCUDO),true)
+ifneq ($(and $(filter true,$(PRODUCT_USE_SCUDO)),$(filter true,$(PRODUCT_USE_SCUDO_32_BIT))),)
   my_sanitize := $(filter-out scudo,$(my_sanitize))
 endif
 

--- a/core/product.mk
+++ b/core/product.mk
@@ -278,8 +278,11 @@ _product_list_vars += PRODUCT_MEMTAG_HEAP_EXCLUDE_PATHS
 # Whether this product wants to start with an empty list of default memtag_heap include paths
 _product_single_value_vars += PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS
 
-# Whether the Scudo hardened allocator is disabled platform-wide
-_product_single_value_vars += PRODUCT_DISABLE_SCUDO
+# Whether the Scudo hardened allocator is enabled platform-wide
+_product_single_value_vars += PRODUCT_USE_SCUDO
+
+# Whether the 32-bit Scudo hardened allocator is enabled platform-wide
+_product_single_value_vars += PRODUCT_USE_SCUDO_32_BIT
 
 # List of extra VNDK versions to be included
 _product_list_vars += PRODUCT_EXTRA_VNDK_VERSIONS

--- a/core/soong_config.mk
+++ b/core/soong_config.mk
@@ -127,8 +127,6 @@ $(call add_json_list, MemtagHeapExcludePaths,            $(MEMTAG_HEAP_EXCLUDE_P
 $(call add_json_list, MemtagHeapAsyncIncludePaths,       $(MEMTAG_HEAP_ASYNC_INCLUDE_PATHS) $(PRODUCT_MEMTAG_HEAP_ASYNC_INCLUDE_PATHS) $(if $(filter true,$(PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS)),,$(PRODUCT_MEMTAG_HEAP_ASYNC_DEFAULT_INCLUDE_PATHS)))
 $(call add_json_list, MemtagHeapSyncIncludePaths,       $(MEMTAG_HEAP_SYNC_INCLUDE_PATHS) $(PRODUCT_MEMTAG_HEAP_SYNC_INCLUDE_PATHS) $(if $(filter true,$(PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS)),,$(PRODUCT_MEMTAG_HEAP_SYNC_DEFAULT_INCLUDE_PATHS)))
 
-$(call add_json_bool, DisableScudo,                      $(filter true,$(PRODUCT_DISABLE_SCUDO)))
-
 $(call add_json_bool, ClangTidy,                         $(filter 1 true,$(WITH_TIDY)))
 $(call add_json_str,  TidyChecks,                        $(WITH_TIDY_CHECKS))
 
@@ -156,10 +154,9 @@ $(call add_json_list, ExtraVndkVersions,                 $(PRODUCT_EXTRA_VNDK_VE
 $(call add_json_list, DeviceSystemSdkVersions,           $(BOARD_SYSTEMSDK_VERSIONS))
 $(call add_json_str,  RecoverySnapshotVersion,           $(RECOVERY_SNAPSHOT_VERSION))
 $(call add_json_list, Platform_systemsdk_versions,       $(PLATFORM_SYSTEMSDK_VERSIONS))
+$(call add_json_bool, Malloc_use_scudo,                  $(filter true,$(PRODUCT_USE_SCUDO)))
 $(call add_json_bool, Malloc_not_svelte,                 $(call invert_bool,$(filter true,$(MALLOC_SVELTE))))
-$(call add_json_bool, Malloc_not_svelte_libc32,          $(if $(MALLOC_SVELTE_FOR_LIBC32),\
-                                                            $(call invert_bool,$(filter true,$(MALLOC_SVELTE_FOR_LIBC32))),\
-                                                            $(call invert_bool,$(filter true,$(MALLOC_SVELTE)))))
+$(call add_json_bool, Malloc_use_scudo_32_bit,           $(filter true,$(PRODUCT_USE_SCUDO_32_BIT)))
 $(call add_json_bool, Malloc_zero_contents,              $(call invert_bool,$(filter false,$(MALLOC_ZERO_CONTENTS))))
 $(call add_json_bool, Malloc_pattern_fill_contents,      $(MALLOC_PATTERN_FILL_CONTENTS))
 $(call add_json_str,  Override_rs_driver,                $(OVERRIDE_RS_DRIVER))

--- a/target/product/go_defaults_common.mk
+++ b/target/product/go_defaults_common.mk
@@ -37,11 +37,6 @@ PRODUCT_ART_TARGET_INCLUDE_DEBUG_BUILD := false
 # leave less information available via JDWP.
 PRODUCT_MINIMIZE_JAVA_DEBUG_INFO := true
 
-# Disable Scudo outside of eng builds to save RAM.
-ifneq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
-  PRODUCT_DISABLE_SCUDO := true
-endif
-
 # Add the system properties.
 TARGET_SYSTEM_PROP += \
     build/make/target/board/go_defaults_common.prop


### PR DESCRIPTION
Set "PRODUCT_USE_SCUDO := true" to device.mk to use scudo in case of a jemalloc compatibility issue.

Also, clean up broken DisableScudo/PRODUCT_DISABLE_SCUDO.

Detailed reason for switching to jemalloc by default is written in the bionic commit.

[minaripenguin: Allow co-existing with 32 bit libc scudo]

Change-Id: I0983c48c1d11afb7820aad66c2838e5e3e13e6e8